### PR TITLE
refactor: remove the push endpoint http prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func create(ctx context.Context, projectID string, topics Topics) error {
 			if len(subscriptionParts) > 1 {
 				pushEndpoint := strings.Replace(subscriptionParts[1], "|", ":", 1)
 				debugf("    Creating push subscription %q with target %q", subscriptionID, pushEndpoint)
-				pushConfig := pubsub.PushConfig{Endpoint: "http://" + pushEndpoint}
+				pushConfig := pubsub.PushConfig{Endpoint: pushEndpoint}
 				_, err = client.CreateSubscription(
 					ctx,
 					subscriptionID,


### PR DESCRIPTION
This change requires that the push endpoint is defined including the protocol as either the environment variable string or docker labels.

I'm aware this is a breaking change so you may want to discuss alternatives.