### PR TITLE
Extended push endpoint protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,17 @@ PUBSUB_PROJECT2=project-two,topicA,topicB:subscriptionX:subscriptionY
 ### Push Subscriptions
 The subscription string can be used to create a push subscription by appending the push endpoint to it separated by a `+`.
 
-#### Example:
+#### Examples:
+**NOTE** We cannot use `:` in the URLs as it conflicts with the pre-existing topic delimiter. So we replace `|` with `:` for you. If you do not provide a protocol, we assume http.
+
 ```
 PUBSUB_PROJECT1=project-name,topic:push-subscription+endpoint
+```
+```
+PUBSUB_PROJECT1=project-name,topic:push-subscription+https|//endpoint/path
+```
+```
+PUBSUB_PROJECT1=project-name,topic:push-subscription+http|//endpoint|8080/path
 ```
 
 ## Docker Labels

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func create(ctx context.Context, projectID string, topics Topics) error {
 			subscriptionParts := strings.Split(subscription, "+")
 			subscriptionID := subscriptionParts[0]
 			if len(subscriptionParts) > 1 {
-				pushEndpoint := strings.Replace(subscriptionParts[1], "|", ":", 1)
+				pushEndpoint := strings.Replace(subscriptionParts[1], "|", ":", 2)
 				if (!strings.HasPrefix(pushEndpoint, "http")) {
 					pushEndpoint = "http://" + pushEndpoint
 				}

--- a/main.go
+++ b/main.go
@@ -91,8 +91,11 @@ func create(ctx context.Context, projectID string, topics Topics) error {
 			subscriptionID := subscriptionParts[0]
 			if len(subscriptionParts) > 1 {
 				pushEndpoint := strings.Replace(subscriptionParts[1], "|", ":", 1)
+				if (!strings.HasPrefix(pushEndpoint, "http")) {
+					pushEndpoint = "http://" + pushEndpoint
+				}
 				debugf("    Creating push subscription %q with target %q", subscriptionID, pushEndpoint)
-				pushConfig := pubsub.PushConfig{Endpoint: "http://" + pushEndpoint}
+				pushConfig := pubsub.PushConfig{Endpoint: pushEndpoint}
 				_, err = client.CreateSubscription(
 					ctx,
 					subscriptionID,


### PR DESCRIPTION
We cannot use `:` in the URLs as it conflicts with the pre-existing topic delimiter. So we replace `|` with `:` for you. If you do not provide a protocol, we assume http.

```
PUBSUB_PROJECT1=project-name,topic:push-subscription+endpoint
```
```
PUBSUB_PROJECT1=project-name,topic:push-subscription+https|//endpoint/path
```
```
PUBSUB_PROJECT1=project-name,topic:push-subscription+http|//endpoint|8080/path
```